### PR TITLE
Circuit breaker test now waits an extend period of time during a test

### DIFF
--- a/test/connectors/DesConnectorSpec.scala
+++ b/test/connectors/DesConnectorSpec.scala
@@ -29,7 +29,7 @@ import org.scalatest.mock.MockitoSugar
 import org.scalatestplus.play._
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers._
-import uk.gov.hmrc.circuitbreaker.UnhealthyServiceException
+import uk.gov.hmrc.circuitbreaker.{CircuitBreakerConfig, UnhealthyServiceException}
 import uk.gov.hmrc.play.audit.http.connector.AuditConnector
 import uk.gov.hmrc.play.http._
 import uk.gov.hmrc.play.http.logging.SessionId
@@ -109,37 +109,36 @@ class DesConnectorSpec extends PlaySpec with OneServerPerSuite with MockitoSugar
               }
       }
 
-//      "return an unhealthy service exception when 503 returned more than {numberOfCallsToTriggerStateChange} times" in {
-//
-//        object Test503DesConnector extends DesConnector {
-//          override val http: HttpGet = mockHttp
-//          override val metrics = mock[Metrics]
-//        }
-//
-//        implicit val hc = new HeaderCarrier(sessionId = Some(SessionId(s"session-${UUID.randomUUID}")))
-//
-//        when(mockHttp.GET[HttpResponse](Matchers.any())(Matchers.any(), Matchers.any()))
-//          .thenReturn(Future.successful(HttpResponse(503,Some(calcResponseJson))))
-//
-//        for(x <- 1 to ApplicationConfig.numberOfCallsToTriggerStateChange){
-//          response503(Test503DesConnector)
-//        }
-//
-//        intercept[UnhealthyServiceException]{
-//          await(Test503DesConnector.calculate(ValidCalculationRequest("S1401234Q", nino, "Smith", "Bill", None, None, None, None, None, None)))
-//          verify(Test503DesConnector.metrics).registerFailedRequest
-//          verify(Test503DesConnector.metrics) registerStatusCode "503"
-//        }
-//
-//
-//      }
-//
-//      def response503(Test503DesConnector:DesConnector)  = {
-//        intercept[Upstream5xxResponse] {
-//          await(Test503DesConnector.calculate(ValidCalculationRequest("S1401234Q", RandomNino.generate, "Smith", "Bill", None, None, None, None, None, None)))
-//          Thread.sleep(10)
-//        }
-//      }
+      "return an unhealthy service exception when 503 returned more than {numberOfCallsToTriggerStateChange} times" in {
+
+        object Test503DesConnector extends DesConnector {
+          override val http: HttpGet = mockHttp
+          override val metrics = mock[Metrics]
+
+          override def circuitBreakerConfig = {
+            CircuitBreakerConfig("DesConnector", 5, 300, 300)
+          }
+        }
+
+        implicit val hc = new HeaderCarrier(sessionId = Some(SessionId(s"session-${UUID.randomUUID}")))
+        val request = ValidCalculationRequest("S1401234Q", RandomNino.generate, "Smith", "Bill", None, None, None, None, None, None)
+
+        when(mockHttp.GET[HttpResponse](Matchers.anyString)(Matchers.any(), Matchers.any()))
+          .thenReturn(Future.successful(HttpResponse(503, Some(calcResponseJson))))
+
+        for(x <- 1 to ApplicationConfig.numberOfCallsToTriggerStateChange){
+          intercept[Upstream5xxResponse] {
+            await(Test503DesConnector.calculate(request))
+            Thread.sleep(2)
+          }
+        }
+
+        intercept[UnhealthyServiceException]{
+          await(Test503DesConnector.calculate(request))
+          verify(Test503DesConnector.metrics).registerFailedRequest
+          verify(Test503DesConnector.metrics) registerStatusCode "503"
+        }
+      }
 
       "return a success when 422 returned" in {
 


### PR DESCRIPTION
This is so that the circuit breaker has no time to reset its status before the next iteration in the test continues (configured value is only 5ms), otherwise the test randomly fails.