### PR TITLE
GMP-1890: Ignore missing MCI check flag

### DIFF
--- a/app/config/ApplicationConfig.scala
+++ b/app/config/ApplicationConfig.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
  
 
 package config

--- a/app/connectors/DesConnector.scala
+++ b/app/connectors/DesConnector.scala
@@ -168,11 +168,11 @@ trait DesConnector extends ServicesConfig with RawResponseReads with UsingCircui
 
       metrics.mciConnectionTimer(System.currentTimeMillis() - startTime, TimeUnit.MILLISECONDS)
 
-      (r.json \ "manualCorrespondenceInd").as[Boolean] match {
-          case false => DesGetSuccessResponse
-          case true  =>
+      (r.json \ "manualCorrespondenceInd").asOpt[Boolean] match {
+          case Some(true) =>
             metrics.registerMciLockResult()
             DesGetHiddenRecordResponse
+          case _ => DesGetSuccessResponse
         }
 
     } recover {

--- a/test/connectors/DesConnectorSpec.scala
+++ b/test/connectors/DesConnectorSpec.scala
@@ -417,6 +417,17 @@ class DesConnectorSpec extends PlaySpec with OneServerPerSuite with MockitoSugar
         await(pd) must be(DesGetErrorResponse(ex))
 
       }
+
+      "return a success response if the MCI flag does not appear in the response" in {
+        val json = Json.parse("{}")
+        val response = HttpResponse(200, Some(json))
+
+        when(mockHttp.GET[HttpResponse](anyString)(any(), any())) thenReturn Future.successful(response)
+
+        val result = TestDesConnector.getPersonDetails("AB123456C")
+
+        await(result) must be(DesGetSuccessResponse)
+      }
     }
   }
 


### PR DESCRIPTION
Protected against the scenario where the MCI flag does not appear in
the response JSON